### PR TITLE
Added login command with dummy auth service

### DIFF
--- a/kismatic.go
+++ b/kismatic.go
@@ -16,9 +16,10 @@
 package main
 
 import (
+	"os"
+
 	"github.com/codegangsta/cli"
 	"github.com/kismatic/kismatic/plugin"
-	"os"
 )
 
 func main() {
@@ -28,6 +29,15 @@ func main() {
 	app.Action = func(c *cli.Context) {
 		// run help
 		println("Run 'kismatic help' for help")
+	}
+
+	// Global flags
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "configuration, c",
+			Value: "",
+			Usage: "path to config file",
+		},
 	}
 
 	app.Commands = []cli.Command{
@@ -57,6 +67,25 @@ func main() {
 						plugin.License(c)
 					},
 				},
+			},
+		},
+		{
+			Name:  "login",
+			Usage: "Login",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "username, u",
+					Value: "",
+					Usage: "Username for authenticating",
+				},
+				cli.StringFlag{
+					Name:  "password, p",
+					Value: "",
+					Usage: "Password for authenticating",
+				},
+			},
+			Action: func(c *cli.Context) {
+				plugin.Login(c)
 			},
 		},
 	}

--- a/plugin/config.go
+++ b/plugin/config.go
@@ -1,0 +1,97 @@
+package plugin
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/user"
+	"path/filepath"
+)
+
+type BackendAuth struct {
+	AuthToken string
+}
+
+type KismaticConfig struct {
+	Auths map[string]BackendAuth
+}
+
+const configFileName = "config.json"
+
+func readConfig() (*KismaticConfig, error) {
+
+	configDir, err := getConfigDir()
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err = os.Stat(configDir); err != nil {
+		if os.IsNotExist(err) {
+			// Create directory if it does not exist
+			if err = os.Mkdir(configDir, 0600); err != nil {
+				return nil, err
+			}
+		} else {
+			return nil, err
+		}
+	}
+
+	configFile := filepath.Join(configDir, configFileName)
+	if _, err = os.Stat(configFile); err != nil {
+		if os.IsNotExist(err) {
+			// Config file does not exist, return empty config struct
+			return &KismaticConfig{Auths: map[string]BackendAuth{}}, nil
+		}
+		return nil, err
+	}
+
+	configJSON, err := ioutil.ReadFile(configFile)
+	if err != nil {
+		return nil, err
+	}
+
+	config := &KismaticConfig{}
+	err = json.Unmarshal(configJSON, config)
+	if err != nil {
+		return nil, err
+	}
+
+	return config, nil
+}
+
+func writeConfig(config *KismaticConfig) error {
+	configJSON, err := json.MarshalIndent(config, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	configDir, err := getConfigDir()
+	if err != nil {
+		return err
+	}
+
+	configFile := filepath.Join(configDir, configFileName)
+
+	return ioutil.WriteFile(configFile, configJSON, 0600)
+}
+
+func deleteConfig() error {
+	configDir, err := getConfigDir()
+	if err != nil {
+		return err
+	}
+
+	configFile := filepath.Join(configDir, configFileName)
+
+	return os.Remove(configFile)
+}
+
+func getConfigDir() (string, error) {
+	usr, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+
+	configDir := filepath.Join(usr.HomeDir, ".kismatic")
+	return configDir, nil
+}

--- a/plugin/login.go
+++ b/plugin/login.go
@@ -1,0 +1,76 @@
+package plugin
+
+import (
+	"fmt"
+
+	"github.com/codegangsta/cli"
+)
+
+// AuthService for authenticating against a backend
+type AuthService interface {
+	// Login user to the given URL with provided username and password
+	Login(url, user, password string) (string, error)
+	// Logout user from the given URL
+	//Logout(url string) error
+}
+
+const defaultServerURL = "someDefaultServer"
+
+// Login command
+func Login(c *cli.Context) {
+	// TODO: Implement auth service
+	authService := dummyAuthService{"token", nil}
+	doLogin(c, authService)
+}
+
+func doLogin(c *cli.Context, authService AuthService) {
+
+	user := c.String("username")
+	password := c.String("password")
+
+	if user == "" || password == "" {
+		fmt.Println("Username and password must be provided.")
+		return
+	}
+
+	serverURL := c.Args().First()
+	if serverURL == "" {
+		serverURL = defaultServerURL
+	}
+
+	// Authenticate against backend
+	authToken, err := authService.Login(serverURL, user, password)
+	if err != nil {
+		fmt.Println("Error authenticating with server.", err)
+		return
+	}
+
+	// Store token in config
+	cfg, err := readConfig()
+	if err != nil {
+		fmt.Println("Error reading config file.", err)
+		return
+	}
+
+	cfg.Auths[serverURL] = BackendAuth{authToken}
+
+	err = writeConfig(cfg)
+	if err != nil {
+		fmt.Println("Error saving config file.", err)
+		return
+	}
+
+	fmt.Println("Login successful. Authentication token saved.")
+}
+
+type dummyAuthService struct {
+	token string
+	err   error
+}
+
+func (das dummyAuthService) Login(url, user, password string) (string, error) {
+	if das.err != nil {
+		return "", das.err
+	}
+	return das.token, nil
+}

--- a/plugin/login_test.go
+++ b/plugin/login_test.go
@@ -1,0 +1,131 @@
+package plugin
+
+import (
+	"flag"
+	"fmt"
+	"testing"
+
+	"github.com/codegangsta/cli"
+)
+
+var tests = []struct {
+	username      string
+	password      string
+	server        string
+	authToken     string
+	authErr       error
+	tokenExpected bool
+}{
+	{
+		username:      "user",
+		password:      "password",
+		server:        "someServer",
+		authToken:     "someToken",
+		authErr:       nil,
+		tokenExpected: true,
+	},
+	{
+		username:      "user",
+		password:      "",
+		server:        "someServer",
+		authToken:     "someToken",
+		authErr:       nil,
+		tokenExpected: false,
+	},
+	{
+		username:      "",
+		password:      "password",
+		server:        "someServer",
+		authToken:     "someToken",
+		authErr:       nil,
+		tokenExpected: false,
+	},
+	{
+		username:      "user",
+		password:      "password",
+		server:        "",
+		authToken:     "someToken",
+		authErr:       nil,
+		tokenExpected: true,
+	},
+	{
+		username:      "user",
+		password:      "password",
+		server:        "",
+		authToken:     "someToken",
+		authErr:       fmt.Errorf("Invalid credentials provided"),
+		tokenExpected: false,
+	},
+}
+
+func TestLoginCmd(t *testing.T) {
+	for _, test := range tests {
+		deleteConfig()
+		context := buildContext(test.username, test.password, test.server)
+		authService := buildAuthService(test.authToken, test.authErr)
+
+		doLogin(context, authService)
+
+		cfg, err := readConfig()
+		if err != nil {
+			t.Error(err)
+		}
+		server := test.server
+		if server == "" {
+			server = defaultServerURL
+		}
+		token := cfg.Auths[server].AuthToken
+
+		if test.tokenExpected && token != test.authToken {
+			t.Error("Expected the token in the config file, but was not there")
+		}
+
+		if token == test.authToken && !test.tokenExpected {
+			t.Error("Token was set in config file, but was not expected.")
+		}
+	}
+}
+
+func TestAuthTokenUpdated(t *testing.T) {
+	deleteConfig()
+	context := buildContext("user", "password", "someServer")
+	authService := buildAuthService("token1", nil)
+
+	doLogin(context, authService)
+
+	cfg, err := readConfig()
+	if err != nil {
+		t.Error("Error reading config", err)
+	}
+	if cfg.Auths["someServer"].AuthToken != "token1" {
+		t.Error("Token was not set in config file")
+	}
+
+	authService2 := buildAuthService("token2", nil)
+
+	doLogin(context, authService2)
+
+	cfg, err = readConfig()
+	if err != nil {
+		t.Error("Error reading config", err)
+	}
+	if cfg.Auths["someServer"].AuthToken != "token2" {
+		t.Error("Token was not updated in config file")
+	}
+
+}
+
+func buildContext(username, password, server string) *cli.Context {
+	set := flag.NewFlagSet("test", 0)
+	set.String("username", "", "")
+	set.String("password", "", "")
+
+	set.Parse([]string{"--username", username, "--password", password, server})
+
+	context := cli.NewContext(nil, set, nil)
+	return context
+}
+
+func buildAuthService(token string, err error) dummyAuthService {
+	return dummyAuthService{token, err}
+}


### PR DESCRIPTION
Initial implementation of the login command, which uses a dummy auth backend.

The auth token is stored in `$HOME/.kismatic/config.json` after successful authentication.

I wasn't sure if a "default server" made sense, but I still included it. 